### PR TITLE
fix: unsupported image data type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ pub fn get_now_playing_info() -> Option<HashMap<String, InfoTypes>> {
                             let date_ref = &*(val_ptr as *const CFDate);
                             InfoTypes::SystemTime(date_ref.to_system_time().unwrap())
                         }
-                        "NSSubrangeData" => {
+                        "NSSubrangeData" | "_NSInlineData" => {
                             let data_ref = &*(val_ptr as *const CFData);
                             InfoTypes::Data(data_ref.to_vec())
                         }


### PR DESCRIPTION
I found that in some cases (e.g. Arc Browser, a chromium-based browser), MacOS provides an `_InlineData` which leads to the album artwork being returned from the library as an `InfoTypes::Unsupported`. 
I tested on Sonoma 14.7.5.