### PR TITLE
fix(jxa): Fix JXA script TypeError when processing media metadata

### DIFF
--- a/src/low_level/nowPlaying.jxa
+++ b/src/low_level/nowPlaying.jxa
@@ -20,7 +20,17 @@ function run() {
   const infoConverted = {};
   for (const key in infoDict.js) {
     const value = infoDict.valueForKey(key).js;
-    infoConverted[key] = typeof value !== "object" ? value : value.getTime();
+     if (typeof value !== "object") {
+      infoConverted[key] = value;
+    } else if (value && typeof value.getTime === "function") {
+      try {
+        infoConverted[key] = value.getTime();
+      } catch (e) {
+        infoConverted[key] = value.toString();
+      }
+    } else {
+      infoConverted[key] = value.toString();
+    }
   }
 
   return JSON.stringify({


### PR DESCRIPTION
- Add safety check for getTime() method before calling it
- Implement try-catch error handling for date conversion
- Fall back to string conversion if getTime() fails
- Resolves "value.getTime is not a function" runtime error