### PR TITLE
fix: memory leak in get_bundle_info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "media-remote"
-version = "0.5.1"
+version = "0.5.2"
 license = "MIT"
 description = "Bindings for MediaRemote.framework"
 readme = "README.md"

--- a/README.md
+++ b/README.md
@@ -368,13 +368,14 @@ Removes a previously added observer.
 
 ### `get_bundle_info(id: &str) -> Option<BundleInfo>`
 
-Retrieves information about an application based on its bundle identifier, including the application's name and icon.
+Retrieves information about an application based on its bundle identifier, including the application's name and (optionally) its icon.
 
 - **Arguments**:
   - `id`: A string slice representing the bundle identifier of the application.
 
 - **Returns**:
-  - `Some(BundleInfo)`: If the application is found, containing the application's name and icon.
+  - `Some(BundleInfo)`: If the application is found, containing the application's name and an `icon` field.
+    - `icon` is `Option<DynamicImage>`: `Some(image)` when the icon could be decoded, or `None` if icon retrieval or decoding failed. The `icon` field is only present when the `artwork` feature is enabled (default).
   - `None`: If the application cannot be found, or if there is an error retrieving the information.
 
 </details>

--- a/src/high_level/now_playing.rs
+++ b/src/high_level/now_playing.rs
@@ -175,7 +175,7 @@ fn update_app(info: Arc<RwLock<Option<NowPlayingInfo>>>) {
             info_guard.as_mut().unwrap().bundle_name = Some(info.name);
             #[cfg(feature = "artwork")]
             {
-                info_guard.as_mut().unwrap().bundle_icon = Some(info.icon);
+                info_guard.as_mut().unwrap().bundle_icon = info.icon;
             }
         }
     }

--- a/src/high_level/now_playing_jxa.rs
+++ b/src/high_level/now_playing_jxa.rs
@@ -46,7 +46,7 @@ pub fn get_info() -> Option<NowPlayingInfo> {
         bundle_id: bundle_id.map(|b| b.to_string()),
         bundle_name: bundle_info.as_ref().map(|b| b.name.clone()),
         #[cfg(feature = "artwork")]
-        bundle_icon: bundle_info.map(|b| b.icon),
+        bundle_icon: bundle_info.and_then(|b| b.icon),
     })
 }
 

--- a/src/high_level/now_playing_perl.rs
+++ b/src/high_level/now_playing_perl.rs
@@ -180,7 +180,7 @@ impl NowPlayingPerl {
                 new_info.bundle_name = Some(bundle_info.name);
                 #[cfg(feature = "artwork")]
                 {
-                    new_info.bundle_icon = Some(bundle_info.icon);
+                    new_info.bundle_icon = bundle_info.icon;
                 }
             }
         }

--- a/src/utils/helpers.rs
+++ b/src/utils/helpers.rs
@@ -1,13 +1,29 @@
 #[cfg(feature = "artwork")]
 use std::io::Cursor;
-use std::ptr::NonNull;
 
 use block2::RcBlock;
+use objc2::rc::{autoreleasepool, Retained};
+
 #[cfg(feature = "artwork")]
 use image::ImageReader;
-use objc2::rc::{autoreleasepool, Retained};
-use objc2_app_kit::NSWorkspace;
-use objc2_foundation::{NSFileManager, NSNotification, NSNotificationCenter, NSString};
+#[cfg(feature = "artwork")]
+use {
+    objc2::{runtime::AnyObject, AnyThread},
+    objc2_app_kit::{
+        NSBitmapImageFileType, NSBitmapImageRep, NSBitmapImageRepPropertyKey, NSWorkspace,
+    },
+    objc2_foundation::{
+        NSDictionary, NSFileManager, NSNotification, NSNotificationCenter, NSString,
+    },
+};
+
+#[cfg(not(feature = "artwork"))]
+use {
+    objc2_app_kit::NSWorkspace,
+    objc2_foundation::{NSFileManager, NSNotification, NSNotificationCenter, NSString},
+};
+
+use std::ptr::NonNull;
 
 #[allow(unused_imports)]
 use crate::{register_for_now_playing_notifications, BundleInfo, Notification, Observer};
@@ -53,13 +69,25 @@ pub fn get_bundle_info(id: &str) -> Option<BundleInfo> {
 
         #[cfg(feature = "artwork")]
         let icon = {
-            let icon = workspace.iconForFile(path);
-            let icon_data = icon.TIFFRepresentation()?;
-            ImageReader::new(Cursor::new(icon_data.to_vec()))
-                .with_guessed_format()
-                .ok()?
-                .decode()
-                .ok()?
+            let image = workspace.iconForFile(path);
+
+            unsafe {
+                let cg_image =
+                    image.CGImageForProposedRect_context_hints(std::ptr::null_mut(), None, None)?;
+                let bitmap_rep = NSBitmapImageRep::alloc();
+                let bitmap_rep = NSBitmapImageRep::initWithCGImage(bitmap_rep, &cg_image);
+                let props = NSDictionary::<NSBitmapImageRepPropertyKey, AnyObject>::new();
+                let data = bitmap_rep
+                    .representationUsingType_properties(NSBitmapImageFileType::PNG, &props)?;
+
+                Some(
+                    ImageReader::new(Cursor::new(data.to_vec()))
+                        .with_guessed_format()
+                        .ok()?
+                        .decode()
+                        .ok()?,
+                )
+            }
         };
 
         Some(BundleInfo {

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -125,7 +125,7 @@ impl Notification {
 pub struct BundleInfo {
     pub name: String,
     #[cfg(feature = "artwork")]
-    pub icon: DynamicImage,
+    pub icon: Option<DynamicImage>,
 }
 
 #[derive(PartialEq, Debug, Clone)]

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -11,7 +11,11 @@ fn test_get_bundle_info() {
             println!("Now playing client parent app info:");
             println!("Name: {}", info.name);
             #[cfg(feature = "artwork")]
-            println!("Icon: {}x{}px", info.icon.width(), info.icon.height());
+            if let Some(icon) = &info.icon {
+                println!("Icon: {}x{}px", icon.width(), icon.height());
+            } else {
+                println!("Icon: None");
+            }
         } else {
             println!("Failed to get now playing client parent app info.");
         }

--- a/tests/test_now_playing.rs
+++ b/tests/test_now_playing.rs
@@ -27,6 +27,8 @@ fn print_info(info: &NowPlayingInfo) {
             bundle_icon.width(),
             bundle_icon.height()
         );
+    } else {
+        println!("Bundle Icon: None");
     }
 }
 

--- a/tests/test_now_playing_jxa.rs
+++ b/tests/test_now_playing_jxa.rs
@@ -27,6 +27,8 @@ fn print_info(info: &NowPlayingInfo) {
             bundle_icon.width(),
             bundle_icon.height()
         );
+    } else {
+        println!("Bundle Icon: None");
     }
 }
 

--- a/tests/test_now_playing_perl.rs
+++ b/tests/test_now_playing_perl.rs
@@ -27,6 +27,8 @@ fn print_info(info: &NowPlayingInfo) {
             bundle_icon.width(),
             bundle_icon.height()
         );
+    } else {
+        println!("Bundle Icon: None");
     }
 }
 


### PR DESCRIPTION
fix #18 and `get_bundle_info ` now return the icon with a higher success rate.